### PR TITLE
Remove email authentication from registration page

### DIFF
--- a/lib/SylSpace/Controller/AuthAuthenticator.pm
+++ b/lib/SylSpace/Controller/AuthAuthenticator.pm
@@ -165,32 +165,9 @@ MSGBODY
 
   <p>Note that G Suite accounts (like <tt>g.ucla.edu</tt>) can also use our Google authentication.</p>
 
-  <hr />
-
-  <p style="font-size:small;padding-top:1em;">Alternatively, use sendmail.  It is slow, throttled per server (to avoid bot DDOS attacks on other servers), may take up to 10 minutes to arrive, and is only valid for 15 minutes&mdash;if you are lucky and no spam filter blocks it, in which case you will have to debug where your IT department or you have blocked the email.  If possible, avoid direct sendmail authentication.  Nevertheless, here it is: </p>
-
-  <form name="registration" method="post" action="/auth/sendmail/authenticate">
-       <input style="display:none" class="form-control" value="no name" name="name" />
-
-    <div class="row text-center">
-
-       <div class="col-md-5">
-         <div class="input-group">
-            <span class="input-group-addon">Email: <i class="fa fa-email"></i></span>
-            <input class="form-control" placeholder="joe.schmoe@ucla.edu" name="outgemaildest" type="email" required />
-         </div>
-       </div>
-
-       <div class="col-md-2">
-          <div class="input-group">
-             <button class="btn btn-default" type="submit" value="submit">Send Authorization Email Now</button>
-          </div>
-      </div>
-
-
   <% } else { %>
 
-   <p style="font-size:small">You did not have a local OAuth config file (usually a link to SylSpace-Secrets.conf), so you cannot use direct or email based registration or authentication.  For now, you can only use this Syllabus webapp reasonably on lvh.me (i.e., localhost), which only allows "local cheating" authentication.</p>
+   <p style="font-size:small">You did not have a local OAuth config file (usually a link to SylSpace-Secrets.conf), so you cannot use direct registration or authentication.  For now, you can only use this Syllabus webapp reasonably on lvh.me (i.e., localhost), which only allows "local cheating" authentication.</p>
 
   <% } %>
 
@@ -201,10 +178,6 @@ MSGBODY
            <%== btnblock('/auth/testsetuser', '<i class="fa fa-users"></i> Choose Existing Listed User', '(works only on localhost, usually lvh.me)', 'btn-warning btn-md', 'w') %>
         </div>
       <% } %>
-
-    </div> <!-- row -->
-
-  </form>
 
 <p style="font-size:x-small;padding-top:1ex"><a href="/auth/magic">magic</a> is only useful to the cli site admin</p>
 


### PR DESCRIPTION
## Summary

Remove the sendmail-based email authentication option from the authentication page, leaving only OAuth providers (Google, Facebook, GitHub) as authentication methods.

## Rationale

The email authentication was described in the UI itself as:
- Slow
- Throttled (to avoid DDOS)
- May take up to 10 minutes to arrive
- Only valid for 15 minutes
- Prone to spam filter issues

This change simplifies the auth flow by removing this unreliable option.

## Changes

- Removed the sendmail form (email input + submit button)
- Removed the explanatory text about sendmail limitations
- Updated the no-OAuth fallback message
- Cleaned up orphaned HTML tags

## Note

`AuthSendmail.pm` still exists but its route is now unreachable from the UI. Consider removing it in a follow-up commit.