### PR TITLE
Add Passkey/WebAuthn authentication

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 ## run with 'carton install'
 requires 'App::Yath', '>= 1.0';
 requires 'Archive::Zip';
+requires 'Authen::WebAuthn';
 requires 'Class::Inspector';
 requires 'Crypt::Blowfish';
 requires 'Crypt::CBC';

--- a/initsylspace.pl
+++ b/initsylspace.pl
@@ -90,7 +90,7 @@ touch("$varsyl/general.log")or die "internal error: I could not touch $varsyl/ge
 chmod(0777, "$varsyl/general.log") or die "chmod: failed on opening $varsyl/general.log to the public: $!\n";
 say STDERR "made $varsyl/general.log";
 
-foreach (qw(users courses tmp templates)) {
+foreach (qw(users courses tmp templates passkeys)) {
   (-e "$varsyl/$_") and next; ## actually should not happen usually
   mkdir("$varsyl/$_") or die "cannot make $varsyl/$_: $!\n";
   chmod(0777, "$varsyl/$_") or die "chmod: failed on chmod-ing $varsyl/$_ to the public: $!\n";

--- a/lib/SylSpace/Controller/AuthAuthenticator.pm
+++ b/lib/SylSpace/Controller/AuthAuthenticator.pm
@@ -167,30 +167,19 @@ MSGBODY
 
   <hr />
 
-  <p style="font-size:small;padding-top:1em;">Alternatively, use sendmail.  It is slow, throttled per server (to avoid bot DDOS attacks on other servers), may take up to 10 minutes to arrive, and is only valid for 15 minutes&mdash;if you are lucky and no spam filter blocks it, in which case you will have to debug where your IT department or you have blocked the email.  If possible, avoid direct sendmail authentication.  Nevertheless, here it is: </p>
+  <p style="font-size:small;padding-top:1em;"><b>Passkey Authentication</b> lets you sign in with Face ID, Touch ID, Windows Hello, or a security key — no password needed.</p>
 
-  <form name="registration" method="post" action="/auth/sendmail/authenticate">
-       <input style="display:none" class="form-control" value="no name" name="name" />
-
-    <div class="row text-center">
-
-       <div class="col-md-5">
-         <div class="input-group">
-            <span class="input-group-addon">Email: <i class="fa fa-email"></i></span>
-            <input class="form-control" placeholder="joe.schmoe@ucla.edu" name="outgemaildest" type="email" required />
-         </div>
-       </div>
-
-       <div class="col-md-2">
-          <div class="input-group">
-             <button class="btn btn-default" type="submit" value="submit">Send Authorization Email Now</button>
-          </div>
-      </div>
-
+   <div class="row text-center">
+     <%== btnblock '/auth/passkey',
+          '<i class="fa fa-key"></i> Sign in with Passkey',
+          'Use Face ID, Touch ID, or Security Key',
+          'btn-info btn-lg'
+        %>
+   </div>
 
   <% } else { %>
 
-   <p style="font-size:small">You did not have a local OAuth config file (usually a link to SylSpace-Secrets.conf), so you cannot use direct or email based registration or authentication.  For now, you can only use this Syllabus webapp reasonably on lvh.me (i.e., localhost), which only allows "local cheating" authentication.</p>
+   <p style="font-size:small">You did not have a local OAuth config file (usually a link to SylSpace-Secrets.conf), so you cannot use direct registration or authentication.  For now, you can only use this Syllabus webapp reasonably on lvh.me (i.e., localhost), which only allows "local cheating" authentication.</p>
 
   <% } %>
 
@@ -201,10 +190,6 @@ MSGBODY
            <%== btnblock('/auth/testsetuser', '<i class="fa fa-users"></i> Choose Existing Listed User', '(works only on localhost, usually lvh.me)', 'btn-warning btn-md', 'w') %>
         </div>
       <% } %>
-
-    </div> <!-- row -->
-
-  </form>
 
 <p style="font-size:x-small;padding-top:1ex"><a href="/auth/magic">magic</a> is only useful to the cli site admin</p>
 

--- a/lib/SylSpace/Controller/AuthPasskey.pm
+++ b/lib/SylSpace/Controller/AuthPasskey.pm
@@ -1,0 +1,555 @@
+#!/usr/bin/env perl
+
+## this file is part of sylspace, released under the AGPL, 2016, authored by ivo welch, ucla.
+## one additional condition requires the prominent posting of the name (sylspace) and the author.
+
+package SylSpace::Controller::AuthPasskey;
+use Mojolicious::Lite;
+use Mojo::JSON qw(decode_json encode_json);
+use MIME::Base64 qw(encode_base64url decode_base64url);
+
+use SylSpace::Model::Model qw(superseclog);
+use SylSpace::Model::Controller qw(global_redirect standard);
+use SylSpace::Model::Utils qw(_getvar);
+
+use Authen::WebAuthn;
+
+my $vardir = _getvar();
+my $passkey_dir = "$vardir/passkeys";
+
+# Ensure passkey storage directory exists
+sub _ensure_passkey_dir {
+  unless (-d $passkey_dir) {
+    mkdir $passkey_dir, 0700 or die "Cannot create $passkey_dir: $!";
+  }
+}
+
+# Get relying party ID from config
+sub _get_rp_id {
+  my $c = shift;
+  my $site = $c->config->{site_name} // 'lvh.me';
+  # RP ID should be the domain without port
+  $site =~ s/:.*//;
+  return $site;
+}
+
+# Get origin URL
+sub _get_origin {
+  my $c = shift;
+  my $site = $c->config->{site_name} // 'lvh.me';
+  my $scheme = ($c->app->mode eq 'development') ? 'http' : 'https';
+  return "$scheme://$site";
+}
+
+# Store passkey credential for user
+sub _store_credential {
+  my ($email, $credential_id, $public_key, $name) = @_;
+  _ensure_passkey_dir();
+  
+  my $user_file = "$passkey_dir/" . _email_to_filename($email);
+  my $creds = [];
+  
+  if (-e $user_file) {
+    local $/;
+    open my $fh, '<', $user_file or die "Cannot read $user_file: $!";
+    my $json = <$fh>;
+    close $fh;
+    $creds = decode_json($json) if $json;
+  }
+  
+  push @$creds, {
+    credential_id => $credential_id,
+    public_key => $public_key,
+    name => $name,
+    created => time(),
+  };
+  
+  open my $fh, '>', $user_file or die "Cannot write $user_file: $!";
+  print $fh encode_json($creds);
+  close $fh;
+}
+
+# Get stored credentials for user
+sub _get_credentials {
+  my ($email) = @_;
+  _ensure_passkey_dir();
+  
+  my $user_file = "$passkey_dir/" . _email_to_filename($email);
+  return [] unless -e $user_file;
+  
+  local $/;
+  open my $fh, '<', $user_file or return [];
+  my $json = <$fh>;
+  close $fh;
+  return decode_json($json) // [];
+}
+
+# Find user by credential ID
+sub _find_user_by_credential {
+  my ($credential_id) = @_;
+  _ensure_passkey_dir();
+  
+  opendir my $dh, $passkey_dir or return (undef, undef);
+  while (my $file = readdir $dh) {
+    next if $file =~ /^\./;
+    my $path = "$passkey_dir/$file";
+    next unless -f $path;
+    
+    local $/;
+    open my $fh, '<', $path or next;
+    my $json = <$fh>;
+    close $fh;
+    
+    my $creds = decode_json($json) // [];
+    for my $cred (@$creds) {
+      if ($cred->{credential_id} eq $credential_id) {
+        my $email = _filename_to_email($file);
+        closedir $dh;
+        return ($email, $cred);
+      }
+    }
+  }
+  closedir $dh;
+  return (undef, undef);
+}
+
+# Convert email to safe filename
+sub _email_to_filename {
+  my $email = shift;
+  $email =~ s/[^a-zA-Z0-9@._-]/_/g;
+  return $email . '.json';
+}
+
+# Convert filename back to email
+sub _filename_to_email {
+  my $file = shift;
+  $file =~ s/\.json$//;
+  return $file;
+}
+
+# Generate random bytes as base64url
+sub _random_base64url {
+  my $len = shift // 32;
+  my $bytes = '';
+  for (1..$len) {
+    $bytes .= chr(int(rand(256)));
+  }
+  return encode_base64url($bytes);
+}
+
+################################################################
+# Registration: Step 1 - Get challenge and options
+################################################################
+
+post '/auth/passkey/register/begin' => sub {
+  my $c = shift;
+  
+  my $email = $c->param('email');
+  my $name = $c->param('name') // $email;
+  
+  unless ($email && $email =~ /.+@.+\..+/) {
+    return $c->render(json => { error => 'Valid email required' }, status => 400);
+  }
+  
+  my $rp_id = _get_rp_id($c);
+  my $challenge = _random_base64url(32);
+  
+  # Store challenge in session for verification
+  $c->session(passkey_challenge => $challenge);
+  $c->session(passkey_email => $email);
+  $c->session(passkey_name => $name);
+  
+  # Create user ID (hash of email)
+  my $user_id = encode_base64url($email);
+  
+  # Get existing credentials to exclude
+  my $existing = _get_credentials($email);
+  my @exclude = map { { type => 'public-key', id => $_->{credential_id} } } @$existing;
+  
+  my $options = {
+    publicKey => {
+      challenge => $challenge,
+      rp => {
+        name => 'SylSpace',
+        id => $rp_id,
+      },
+      user => {
+        id => $user_id,
+        name => $email,
+        displayName => $name,
+      },
+      pubKeyCredParams => [
+        { type => 'public-key', alg => -7 },   # ES256
+        { type => 'public-key', alg => -257 }, # RS256
+      ],
+      timeout => 60000,
+      attestation => 'none',
+      authenticatorSelection => {
+        authenticatorAttachment => 'platform',
+        residentKey => 'preferred',
+        userVerification => 'preferred',
+      },
+      excludeCredentials => \@exclude,
+    }
+  };
+  
+  $c->render(json => $options);
+};
+
+################################################################
+# Registration: Step 2 - Verify and store credential
+################################################################
+
+post '/auth/passkey/register/finish' => sub {
+  my $c = shift;
+  
+  my $challenge = $c->session('passkey_challenge');
+  my $email = $c->session('passkey_email');
+  my $name = $c->session('passkey_name');
+  
+  unless ($challenge && $email) {
+    return $c->render(json => { error => 'Session expired, please try again' }, status => 400);
+  }
+  
+  my $credential = $c->req->json;
+  unless ($credential && $credential->{id}) {
+    return $c->render(json => { error => 'Invalid credential data' }, status => 400);
+  }
+  
+  my $rp_id = _get_rp_id($c);
+  my $origin = _get_origin($c);
+  
+  eval {
+    my $webauthn = Authen::WebAuthn->new(
+      rp_id => $rp_id,
+      origin => $origin,
+    );
+    
+    my $result = $webauthn->validate_registration(
+      challenge_b64 => $challenge,
+      client_data_json_b64 => $credential->{response}{clientDataJSON},
+      attestation_object_b64 => $credential->{response}{attestationObject},
+      requested_uv => 'preferred',
+    );
+    
+    # Store the credential
+    _store_credential(
+      $email,
+      $credential->{id},
+      $result->{credential_pubkey},
+      $name
+    );
+    
+    # Clear session
+    delete $c->session->{passkey_challenge};
+    delete $c->session->{passkey_email};
+    delete $c->session->{passkey_name};
+    
+    superseclog($c->tx->remote_address, $email, "registered passkey for $email");
+    
+    $c->render(json => { success => 1, message => 'Passkey registered successfully' });
+  };
+  if ($@) {
+    $c->app->log->error("Passkey registration failed: $@");
+    $c->render(json => { error => "Registration failed: $@" }, status => 400);
+  }
+};
+
+################################################################
+# Authentication: Step 1 - Get challenge
+################################################################
+
+post '/auth/passkey/login/begin' => sub {
+  my $c = shift;
+  
+  my $rp_id = _get_rp_id($c);
+  my $challenge = _random_base64url(32);
+  
+  $c->session(passkey_auth_challenge => $challenge);
+  
+  # For discoverable credentials, we don't need to specify allowCredentials
+  my $options = {
+    publicKey => {
+      challenge => $challenge,
+      rpId => $rp_id,
+      timeout => 60000,
+      userVerification => 'preferred',
+    }
+  };
+  
+  $c->render(json => $options);
+};
+
+################################################################
+# Authentication: Step 2 - Verify assertion
+################################################################
+
+post '/auth/passkey/login/finish' => sub {
+  my $c = shift;
+  
+  my $challenge = $c->session('passkey_auth_challenge');
+  unless ($challenge) {
+    return $c->render(json => { error => 'Session expired, please try again' }, status => 400);
+  }
+  
+  my $assertion = $c->req->json;
+  unless ($assertion && $assertion->{id}) {
+    return $c->render(json => { error => 'Invalid assertion data' }, status => 400);
+  }
+  
+  my $credential_id = $assertion->{id};
+  my ($email, $stored_cred) = _find_user_by_credential($credential_id);
+  
+  unless ($email && $stored_cred) {
+    return $c->render(json => { error => 'Unknown credential' }, status => 400);
+  }
+  
+  my $rp_id = _get_rp_id($c);
+  my $origin = _get_origin($c);
+  
+  eval {
+    my $webauthn = Authen::WebAuthn->new(
+      rp_id => $rp_id,
+      origin => $origin,
+    );
+    
+    $webauthn->validate_assertion(
+      challenge_b64 => $challenge,
+      credential_pubkey => $stored_cred->{public_key},
+      stored_sign_count => $stored_cred->{sign_count} // 0,
+      client_data_json_b64 => $assertion->{response}{clientDataJSON},
+      authenticator_data_b64 => $assertion->{response}{authenticatorData},
+      signature_b64 => $assertion->{response}{signature},
+      requested_uv => 'preferred',
+    );
+    
+    # Clear challenge
+    delete $c->session->{passkey_auth_challenge};
+    
+    # Log in the user
+    my $name = $stored_cred->{name} // $email;
+    superseclog($c->tx->remote_address, $email, "logged in $email via passkey");
+    $c->session(uemail => $email, name => $name, expiration => time()+60*60);
+    
+    $c->render(json => { success => 1, redirect => '/index' });
+  };
+  if ($@) {
+    $c->app->log->error("Passkey authentication failed: $@");
+    $c->render(json => { error => "Authentication failed: $@" }, status => 400);
+  }
+};
+
+################################################################
+# Passkey registration/login page
+################################################################
+
+get '/auth/passkey' => sub {
+  my $c = shift;
+  (my $course = standard($c)) or return global_redirect($c);
+  $c->render(template => 'AuthPasskey');
+};
+
+1;
+
+################################################################
+
+__DATA__
+
+@@ AuthPasskey.html.ep
+
+%title 'Passkey Authentication';
+%layout 'auth';
+
+<main>
+
+<h2>Passkey Authentication</h2>
+
+<p>Passkeys let you sign in securely using Face ID, Touch ID, Windows Hello, or a security key — no password needed.</p>
+
+<div id="passkey-status" class="alert" style="display:none;"></div>
+
+<hr />
+
+<h3>Sign in with Passkey</h3>
+<p>If you've already registered a passkey, click below to sign in:</p>
+<button id="passkey-login-btn" class="btn btn-primary btn-lg">
+  <i class="fa fa-key"></i> Sign in with Passkey
+</button>
+
+<hr />
+
+<h3>Register a new Passkey</h3>
+<p>First time? Enter your email to create a passkey for this device:</p>
+
+<div class="form-group">
+  <label for="passkey-email">Email:</label>
+  <input type="email" id="passkey-email" class="form-control" placeholder="you@example.com" required />
+</div>
+<div class="form-group">
+  <label for="passkey-name">Name (optional):</label>
+  <input type="text" id="passkey-name" class="form-control" placeholder="Your Name" />
+</div>
+<button id="passkey-register-btn" class="btn btn-success btn-lg">
+  <i class="fa fa-plus"></i> Register Passkey
+</button>
+
+<hr />
+<p><a href="/auth/authenticator">&larr; Back to other sign-in options</a></p>
+
+</main>
+
+<script>
+// Helper: base64url encode/decode
+function base64urlToBuffer(base64url) {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = base64.length % 4;
+  const padded = pad ? base64 + '='.repeat(4 - pad) : base64;
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function bufferToBase64url(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function showStatus(msg, isError) {
+  const el = document.getElementById('passkey-status');
+  el.textContent = msg;
+  el.className = 'alert ' + (isError ? 'alert-danger' : 'alert-success');
+  el.style.display = 'block';
+}
+
+// Check if WebAuthn is supported
+if (!window.PublicKeyCredential) {
+  showStatus('Passkeys are not supported in this browser. Please use a modern browser.', true);
+  document.getElementById('passkey-login-btn').disabled = true;
+  document.getElementById('passkey-register-btn').disabled = true;
+}
+
+// Register passkey
+document.getElementById('passkey-register-btn').addEventListener('click', async function() {
+  const email = document.getElementById('passkey-email').value;
+  const name = document.getElementById('passkey-name').value || email;
+  
+  if (!email || !email.includes('@')) {
+    showStatus('Please enter a valid email address.', true);
+    return;
+  }
+  
+  try {
+    // Get registration options from server
+    const optionsRes = await fetch('/auth/passkey/register/begin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'email=' + encodeURIComponent(email) + '&name=' + encodeURIComponent(name)
+    });
+    const options = await optionsRes.json();
+    
+    if (options.error) {
+      showStatus(options.error, true);
+      return;
+    }
+    
+    // Convert base64url to ArrayBuffer
+    options.publicKey.challenge = base64urlToBuffer(options.publicKey.challenge);
+    options.publicKey.user.id = base64urlToBuffer(options.publicKey.user.id);
+    if (options.publicKey.excludeCredentials) {
+      options.publicKey.excludeCredentials = options.publicKey.excludeCredentials.map(c => ({
+        ...c,
+        id: base64urlToBuffer(c.id)
+      }));
+    }
+    
+    // Create credential
+    const credential = await navigator.credentials.create(options);
+    
+    // Send to server
+    const finishRes = await fetch('/auth/passkey/register/finish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: credential.id,
+        rawId: bufferToBase64url(credential.rawId),
+        type: credential.type,
+        response: {
+          clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+          attestationObject: bufferToBase64url(credential.response.attestationObject)
+        }
+      })
+    });
+    const result = await finishRes.json();
+    
+    if (result.success) {
+      showStatus('Passkey registered! You can now sign in with it.', false);
+    } else {
+      showStatus(result.error || 'Registration failed', true);
+    }
+  } catch (err) {
+    console.error(err);
+    showStatus('Error: ' + err.message, true);
+  }
+});
+
+// Login with passkey
+document.getElementById('passkey-login-btn').addEventListener('click', async function() {
+  try {
+    // Get authentication options from server
+    const optionsRes = await fetch('/auth/passkey/login/begin', {
+      method: 'POST'
+    });
+    const options = await optionsRes.json();
+    
+    if (options.error) {
+      showStatus(options.error, true);
+      return;
+    }
+    
+    // Convert challenge to ArrayBuffer
+    options.publicKey.challenge = base64urlToBuffer(options.publicKey.challenge);
+    
+    // Get credential
+    const assertion = await navigator.credentials.get(options);
+    
+    // Send to server
+    const finishRes = await fetch('/auth/passkey/login/finish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: assertion.id,
+        rawId: bufferToBase64url(assertion.rawId),
+        type: assertion.type,
+        response: {
+          clientDataJSON: bufferToBase64url(assertion.response.clientDataJSON),
+          authenticatorData: bufferToBase64url(assertion.response.authenticatorData),
+          signature: bufferToBase64url(assertion.response.signature),
+          userHandle: assertion.response.userHandle ? bufferToBase64url(assertion.response.userHandle) : null
+        }
+      })
+    });
+    const result = await finishRes.json();
+    
+    if (result.success) {
+      showStatus('Success! Redirecting...', false);
+      window.location.href = result.redirect || '/index';
+    } else {
+      showStatus(result.error || 'Login failed', true);
+    }
+  } catch (err) {
+    console.error(err);
+    if (err.name === 'NotAllowedError') {
+      showStatus('Authentication was cancelled or timed out.', true);
+    } else {
+      showStatus('Error: ' + err.message, true);
+    }
+  }
+});
+</script>


### PR DESCRIPTION
## Summary

Add passwordless authentication using Passkeys (WebAuthn). Users can sign in with Face ID, Touch ID, Windows Hello, or security keys.

## Why Passkeys?

- **Free**: No developer fees (unlike Apple Sign In)
- **Secure**: Phishing-resistant, cryptographic authentication
- **Universal**: Works on Apple, Android, Windows, Linux
- **Easy**: No passwords to remember

## Changes

### New Files
- `lib/SylSpace/Controller/AuthPasskey.pm` - WebAuthn registration and authentication endpoints with embedded template

### Modified Files
- `cpanfile` - Added `Authen::WebAuthn` dependency
- `lib/SylSpace/Controller/AuthAuthenticator.pm` - Added passkey button to auth page
- `initsylspace.pl` - Create `passkeys/` directory during initialization

## How it works

1. **Registration**: User enters email, browser prompts for biometric/security key, credential stored server-side
2. **Login**: User clicks "Sign in with Passkey", browser prompts for biometric/security key, server verifies

## After merging

Run `carton install` to install the new `Authen::WebAuthn` dependency.

If updating an existing installation, create the passkeys directory:
```bash
mkdir -p /var/sylspace/passkeys
chmod 700 /var/sylspace/passkeys
```